### PR TITLE
fix: ensure Dockerfile matches happy path configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 8080
+ENV PORT=3000
+EXPOSE ${PORT}
+
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Although the "Deploy via Dockerfile" quickstart docs suggest fly will default to :8080 and will automatically use an EXPOSEd port if set, the observed behavior is that :3000 is always used instead.

Update Dockerfile to use :3000 and set the $PORT environment variable to ensure the application listens on the configured port.

Resolves #5
